### PR TITLE
feat: migrate to sqlite and add auth bypass toggles

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,11 +2,22 @@
 # Copy this file to .env and modify as needed:
 #   cp .env.example .env
 
-# Admin PIN for login (change this!)
-ADMIN_PIN="1111"
+# Toggle Database Provider (postgresql or sqlite)
+DB_PROVIDER=sqlite
 
-# Database password (change for production!)
+# If DB_PROVIDER=sqlite, the backend defaults to file:./dev.db locally.
+# In Docker, we use the DATABASE_URL below to store it in /app/data
+DATABASE_URL=file:../data/inker.db
+
+# If DB_PROVIDER=postgresql, you'll need the POSTGRES_PASSWORD for the Docker container:
 POSTGRES_PASSWORD=inker_password
+
+# Authentication (Set to false to skip the login screen entirely)
+AUTH_ENABLED=false
+VITE_AUTH_ENABLED=false
+
+# Admin PIN for login (if AUTH_ENABLED=true)
+ADMIN_PIN="1111"
 
 # Timezone for clock/date widgets
 TZ=UTC

--- a/.gitignore
+++ b/.gitignore
@@ -48,3 +48,4 @@ uploads/*
 # Test coverage
 coverage/
 .nyc_output/
+data/

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,12 +12,19 @@ COPY frontend/package.json frontend/bun.lock* ./
 RUN bun install --frozen-lockfile
 
 COPY frontend/ .
+
+# Accept optional build argument to toggle authentication
+ARG VITE_AUTH_ENABLED
+ENV VITE_AUTH_ENABLED=${VITE_AUTH_ENABLED}
+
 RUN bun run build
 
 # =============================================================================
 # Stage 2: Install backend production dependencies
 # =============================================================================
 FROM oven/bun:1-slim AS backend-install
+ARG DB_PROVIDER=postgresql
+ENV DB_PROVIDER=${DB_PROVIDER}
 
 WORKDIR /app
 
@@ -28,9 +35,11 @@ RUN apt-get update && apt-get install -y --no-install-recommends openssl && rm -
 
 COPY backend/package.json backend/bun.lock* ./
 COPY backend/prisma ./prisma/
+COPY backend/scripts ./scripts/
 
 # Install all deps → generate prisma → reinstall production-only → prune
 RUN bun install --frozen-lockfile && \
+    node scripts/set-db-provider.js && \
     node ./node_modules/prisma/build/index.js generate && \
     cp -r node_modules/.prisma /tmp/.prisma && \
     rm -rf node_modules && \
@@ -58,6 +67,8 @@ RUN bun install --frozen-lockfile && \
 # Stage 3: Build backend
 # =============================================================================
 FROM oven/bun:1-slim AS backend-builder
+ARG DB_PROVIDER=postgresql
+ENV DB_PROVIDER=${DB_PROVIDER}
 
 WORKDIR /app
 
@@ -69,7 +80,8 @@ COPY backend/package.json backend/bun.lock* ./
 RUN bun install --frozen-lockfile
 
 COPY backend/prisma ./prisma/
-RUN node ./node_modules/prisma/build/index.js generate
+COPY backend/scripts ./scripts/
+RUN node scripts/set-db-provider.js && node ./node_modules/prisma/build/index.js generate && node scripts/fix-prisma-types.js
 
 COPY backend/ .
 RUN bun run build
@@ -80,11 +92,16 @@ RUN bun run build
 FROM debian:trixie-slim AS production
 
 ARG S6_OVERLAY_VERSION=3.2.1.0
+ARG DB_PROVIDER=postgresql
+ENV DB_PROVIDER=${DB_PROVIDER}
 
 # Install all system packages in one layer
-RUN apt-get update && apt-get install -y --no-install-recommends \
-    # PostgreSQL
-    postgresql-17 \
+RUN apt-get update && \
+    # Install postgresql only if DB_PROVIDER is postgresql
+    if [ "$DB_PROVIDER" = "postgresql" ]; then \
+        apt-get install -y --no-install-recommends postgresql-17; \
+    fi && \
+    apt-get install -y --no-install-recommends \
     # Redis
     redis-server \
     # Nginx
@@ -119,11 +136,13 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     rm /tmp/s6-noarch.tar.xz /tmp/s6-x86_64.tar.xz && \
     # Install PostgreSQL 15 from PGDG for data migration (15→17) support
     # Existing users upgrading from bookworm need PG 15 binaries to dump their data
-    echo "deb http://apt.postgresql.org/pub/repos/apt trixie-pgdg main" > /etc/apt/sources.list.d/pgdg.list && \
-    wget -qO /etc/apt/trusted.gpg.d/pgdg.asc https://www.postgresql.org/media/keys/ACCC4CF8.asc && \
-    apt-get update -qq && \
-    apt-get install -y -qq --no-install-recommends postgresql-15 >/dev/null 2>&1 && \
-    rm -rf /var/lib/postgresql/15 /etc/apt/sources.list.d/pgdg.list && \
+    if [ "$DB_PROVIDER" = "postgresql" ]; then \
+        echo "deb http://apt.postgresql.org/pub/repos/apt trixie-pgdg main" > /etc/apt/sources.list.d/pgdg.list && \
+        wget -qO /etc/apt/trusted.gpg.d/pgdg.asc https://www.postgresql.org/media/keys/ACCC4CF8.asc && \
+        apt-get update -qq && \
+        apt-get install -y -qq --no-install-recommends postgresql-15 >/dev/null 2>&1 && \
+        rm -rf /var/lib/postgresql/15 /etc/apt/sources.list.d/pgdg.list; \
+    fi && \
     # Remove build-only tools normally
     apt-get purge -y unzip xz-utils wget && apt-get autoremove -y && \
     # Force-remove transitive deps not needed at runtime
@@ -139,7 +158,9 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
            /usr/share/info /usr/share/lintian /usr/share/X11/xkb \
            /var/cache/debconf/*-old && \
     # Remove auto-created PostgreSQL cluster (will be initialized on first run)
-    rm -rf /var/lib/postgresql/17/main/*
+    if [ "$DB_PROVIDER" = "postgresql" ]; then \
+        rm -rf /var/lib/postgresql/17/main/*; \
+    fi
 
 # Install Bun runtime (copy from build image)
 COPY --from=oven/bun:1-slim /usr/local/bin/bun /usr/local/bin/bun
@@ -171,7 +192,7 @@ WORKDIR /app
 COPY --from=backend-install /app/node_modules ./node_modules
 
 # Copy Prisma schema and generated client
-COPY backend/prisma ./prisma/
+COPY --from=backend-install /app/prisma ./prisma/
 COPY --from=backend-install /app/node_modules/.prisma ./node_modules/.prisma
 COPY --from=backend-install /app/node_modules/@prisma ./node_modules/@prisma
 
@@ -200,9 +221,12 @@ RUN chmod +x /etc/cont-init.d/* && \
 
 # Create required directories
 RUN mkdir -p /app/uploads/screens /app/uploads/firmware /app/uploads/widgets \
-    /app/uploads/captures /app/uploads/drawings /app/logs \
-    /data /var/lib/postgresql/17/main /run/postgresql && \
-    chown -R postgres:postgres /var/lib/postgresql /run/postgresql
+    /app/uploads/captures /app/uploads/drawings /app/logs /app/data \
+    /data && \
+    if [ "$DB_PROVIDER" = "postgresql" ]; then \
+        mkdir -p /var/lib/postgresql/17/main /run/postgresql && \
+        chown -R postgres:postgres /var/lib/postgresql /run/postgresql; \
+    fi
 
 # Create non-root user for backend process
 RUN useradd --system --no-create-home --shell /usr/sbin/nologin inker && \

--- a/backend/package.json
+++ b/backend/package.json
@@ -13,8 +13,8 @@
     "test": "bun test",
     "test:watch": "bun test --watch",
     "test:cov": "bun test --coverage",
-    "prisma:generate": "bunx prisma generate",
-    "prisma:migrate": "bunx prisma migrate dev",
+    "prisma:generate": "node scripts/set-db-provider.js && bunx prisma generate && node scripts/fix-prisma-types.js",
+    "prisma:migrate": "node scripts/set-db-provider.js && bunx prisma migrate dev && node scripts/fix-prisma-types.js",
     "prisma:studio": "bunx prisma studio",
     "prisma:seed": "bun run prisma/seed.ts",
     "db:seed": "bun run prisma:seed"

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -5,7 +5,7 @@ generator client {
 }
 
 datasource db {
-  provider = "postgresql"
+  provider = "sqlite"
   url      = env("DATABASE_URL")
 }
 
@@ -124,7 +124,7 @@ model Extension {
   name        String
   description String?
   type        String   // webhook, polling, custom
-  config      Json     // JSON configuration
+  config      String     // JSON configuration
   isActive    Boolean  @default(true) @map("is_active")
   createdAt   DateTime @default(now()) @map("created_at")
   updatedAt   DateTime @updatedAt @map("updated_at")
@@ -144,12 +144,12 @@ model DataSource {
   type            String    // "json" | "rss"
   url             String    // API endpoint or RSS feed URL
   method          String    @default("GET") // HTTP method for JSON APIs
-  headers         Json?     // Custom headers (e.g., API keys)
+  headers         String?     // Custom headers (e.g., API keys)
   refreshInterval Int       @default(300) @map("refresh_interval") // Seconds between fetches
   jsonPath        String?   @map("json_path") // JSONPath expression to extract data
   isActive        Boolean   @default(true) @map("is_active")
   lastFetchedAt   DateTime? @map("last_fetched_at")
-  lastData        Json?     @map("last_data") // Cached response data
+  lastData        String?     @map("last_data") // Cached response data
   lastError       String?   @map("last_error") // Last fetch error message
   createdAt       DateTime  @default(now()) @map("created_at")
   updatedAt       DateTime  @updatedAt @map("updated_at")
@@ -167,7 +167,7 @@ model CustomWidget {
   dataSourceId  Int      @map("data_source_id")
   displayType   String   // "template" | "value" | "list" | "title-value"
   template      String?  // Template string for "template" display type
-  config        Json     @default("{}") // Layout config (fontSize, alignment, etc.)
+  config        String     @default("{}") // Layout config (fontSize, alignment, etc.)
   minWidth      Int      @default(100) @map("min_width")
   minHeight     Int      @default(50) @map("min_height")
   createdAt     DateTime @default(now()) @map("created_at")
@@ -194,7 +194,7 @@ model DeviceLog {
   deviceId  Int      @map("device_id")
   level     String   // info, warning, error
   message   String
-  metadata  Json?
+  metadata  String?
   createdAt DateTime @default(now()) @map("created_at")
 
   device    Device   @relation(fields: [deviceId], references: [id], onDelete: Cascade)
@@ -213,7 +213,7 @@ model WidgetTemplate {
   label         String   // Display name: "Live Clock", "Weather"
   description   String?
   category      String   // "time", "weather", "content", "system"
-  defaultConfig Json     // Default configuration for this widget type
+  defaultConfig String     // Default configuration for this widget type
   minWidth      Int      @default(100) @map("min_width")
   minHeight     Int      @default(50) @map("min_height")
   createdAt     DateTime @default(now()) @map("created_at")
@@ -252,7 +252,7 @@ model ScreenWidget {
   width          Int      @default(200)
   height         Int      @default(100)
   rotation       Int      @default(0) // Rotation in degrees (0, 90, 180, 270, or any angle)
-  config         Json     // Widget-specific config (timezone, location, etc.)
+  config         String     // Widget-specific config (timezone, location, etc.)
   zIndex         Int      @default(0) @map("z_index")
   createdAt      DateTime @default(now()) @map("created_at")
   updatedAt      DateTime @updatedAt @map("updated_at")
@@ -316,7 +316,7 @@ model Plugin {
   dataStrategy         String   @default("polling") @map("data_strategy") // polling | webhook | static
   dataUrl              String?  @map("data_url")     // supports {{setting}} interpolation
   dataMethod           String   @default("GET") @map("data_method")
-  dataHeaders          Json?    @map("data_headers")  // supports {{setting}} interpolation
+  dataHeaders          String?    @map("data_headers")  // supports {{setting}} interpolation
   dataPath             String?  @map("data_path")     // JSONPath to extract from response
   dataTransform        String?  @map("data_transform") // JS script to transform fetched data into locals
   refreshInterval      Int      @default(300) @map("refresh_interval") // seconds
@@ -328,7 +328,7 @@ model Plugin {
   markupQuadrant       String?  @map("markup_quadrant")
 
   // Settings schema: [{key, label, type, options?, required?, encrypted?, default?}]
-  settingsSchema       Json?    @map("settings_schema")
+  settingsSchema       String?    @map("settings_schema")
 
   // OAuth (for plugins that require OAuth2 authentication)
   oauthProvider        String?  @map("oauth_provider")  // "google" | "spotify" | "strava" etc.
@@ -355,8 +355,8 @@ model PluginInstance {
   pluginId             Int      @map("plugin_id")
   name                 String?  // optional custom name for this instance
 
-  settings             Json     @default("{}") // user settings (non-sensitive)
-  settingsEncrypted    Json     @default("{}") @map("settings_encrypted") // encrypted settings (API keys)
+  settings             String     @default("{}") // user settings (non-sensitive)
+  settingsEncrypted    String     @default("{}") @map("settings_encrypted") // encrypted settings (API keys)
 
   // OAuth tokens (encrypted)
   oauthToken           String?  @map("oauth_token")         // encrypted access token
@@ -364,7 +364,7 @@ model PluginInstance {
   oauthExpiresAt       DateTime? @map("oauth_expires_at")
 
   // Cached data (the locals hash)
-  lastData             Json?    @map("last_data")
+  lastData             String?    @map("last_data")
   lastFetchedAt        DateTime? @map("last_fetched_at")
   lastError            String?  @map("last_error")
 

--- a/backend/scripts/fix-prisma-types.js
+++ b/backend/scripts/fix-prisma-types.js
@@ -1,0 +1,23 @@
+const fs = require('fs');
+const path = require('path');
+const dtsPath = path.join(__dirname, '../node_modules/.prisma/client/index.d.ts');
+if (fs.existsSync(dtsPath)) {
+  let dts = fs.readFileSync(dtsPath, 'utf8');
+  const fields = ['config', 'headers', 'lastData', 'metadata', 'defaultConfig', 'dataHeaders', 'settingsSchema', 'settings', 'settingsEncrypted'];
+  fields.forEach(field => {
+    // Replace simple "field: string" or "field?: string" or "field: string | null"
+    dts = dts.replace(new RegExp(`(\\b${field}\\s*\\??\\s*:)\\s*string(\\s*\\|\\s*null)?(?=[\\n\\r;,])`, 'g'), `$1 any`);
+    
+    // Replace "field?: NullableStringFieldUpdateOperationsInput | string | null"
+    dts = dts.replace(new RegExp(`(\\b${field}\\s*\\??\\s*:)\\s*[a-zA-Z<>\\"_]+\\s*\\|\\s*string\\s*\\|\\s*null(?=[\\n\\r;,])`, 'g'), `$1 any`);
+    
+    // Replace "field?: StringFieldUpdateOperationsInput | string"
+    dts = dts.replace(new RegExp(`(\\b${field}\\s*\\??\\s*:)\\s*[a-zA-Z<>\\"_]+\\s*\\|\\s*string(?=[\\n\\r;,])`, 'g'), `$1 any`);
+  });
+  
+  // replace Prisma.DbNull
+  dts = dts.replace(/Prisma\.DbNull/g, 'any');
+  
+  fs.writeFileSync(dtsPath, dts);
+  console.log('Fixed Prisma TS types for SQLite');
+}

--- a/backend/scripts/set-db-provider.js
+++ b/backend/scripts/set-db-provider.js
@@ -1,0 +1,20 @@
+const fs = require('fs');
+const path = require('path');
+
+const provider = process.env.DB_PROVIDER || 'postgresql';
+const schemaPath = path.join(__dirname, '../prisma/schema.prisma');
+
+let schema = fs.readFileSync(schemaPath, 'utf8');
+
+schema = schema.replace(
+  /datasource db \{\s*provider\s*=\s*"[^"]+"\s*url\s*=\s*env\("DATABASE_URL"\)\s*\}/,
+  `datasource db {\n  provider = "${provider}"\n  url      = env("DATABASE_URL")\n}`
+);
+
+if (provider === 'sqlite') {
+  schema = schema.replace(/ Json\?/g, ' String?');
+  schema = schema.replace(/ Json/g, ' String');
+}
+
+fs.writeFileSync(schemaPath, schema);
+console.log(`Database provider set to: ${provider}`);

--- a/backend/src/auth/guards/pin-auth.guard.ts
+++ b/backend/src/auth/guards/pin-auth.guard.ts
@@ -1,5 +1,6 @@
 import { Injectable, ExecutionContext, CanActivate, UnauthorizedException } from '@nestjs/common';
 import { Reflector } from '@nestjs/core';
+import { ConfigService } from '@nestjs/config';
 import { IS_PUBLIC_KEY } from '../../common/decorators/public.decorator';
 import { PinAuthService } from '../pin-auth.service';
 
@@ -13,9 +14,16 @@ export class PinAuthGuard implements CanActivate {
   constructor(
     private reflector: Reflector,
     private pinAuthService: PinAuthService,
+    private configService: ConfigService,
   ) {}
 
   canActivate(context: ExecutionContext): boolean {
+    // Check if auth is disabled via environment variables
+    const authEnabled = this.configService.get<boolean>('auth.enabled');
+    if (authEnabled === false) {
+      return true;
+    }
+
     // Check if route is marked as public
     const isPublic = this.reflector.getAllAndOverride<boolean>(IS_PUBLIC_KEY, [
       context.getHandler(),

--- a/backend/src/config/configuration.ts
+++ b/backend/src/config/configuration.ts
@@ -9,7 +9,12 @@ export const configuration = () => ({
   inkerPort: parseInt(process.env.INKER_PORT || '80', 10),
 
   database: {
+    provider: process.env.DB_PROVIDER || 'postgresql',
     url: process.env.DATABASE_URL,
+  },
+
+  auth: {
+    enabled: process.env.AUTH_ENABLED !== 'false',
   },
 
   redis: {

--- a/backend/src/config/validation.schema.ts
+++ b/backend/src/config/validation.schema.ts
@@ -7,7 +7,11 @@ export const validationSchema = Joi.object({
   PORT: Joi.number().default(3000),
 
   // Database
+  DB_PROVIDER: Joi.string().valid('postgresql', 'sqlite').default('postgresql'),
   DATABASE_URL: Joi.string().required(),
+
+  // Auth bypass
+  AUTH_ENABLED: Joi.boolean().default(true),
 
   // Redis
   REDIS_HOST: Joi.string().default('localhost'),

--- a/backend/src/prisma/prisma.service.ts
+++ b/backend/src/prisma/prisma.service.ts
@@ -25,6 +25,62 @@ export class PrismaService extends PrismaClient implements OnModuleInit, OnModul
         this.logger.debug(`Query: ${e.query} | Duration: ${e.duration}ms`);
       });
     }
+
+    // Apply SQLite JSON fallback middleware
+    if (process.env.DB_PROVIDER === 'sqlite') {
+      const jsonFields = new Set([
+        'config', 'headers', 'lastData', 'metadata', 'defaultConfig',
+        'dataHeaders', 'settingsSchema', 'settings', 'settingsEncrypted'
+      ]);
+
+      const stringifyJsonFields = (obj: any) => {
+        if (!obj || typeof obj !== 'object') return;
+        for (const key of Object.keys(obj)) {
+          if (jsonFields.has(key)) {
+            if (typeof obj[key] !== 'string' && obj[key] !== null && obj[key] !== undefined) {
+              obj[key] = JSON.stringify(obj[key]);
+            }
+          } else if (typeof obj[key] === 'object' && obj[key] !== null) {
+            stringifyJsonFields(obj[key]);
+          }
+        }
+      };
+
+      const parseJsonFields = (obj: any) => {
+        if (!obj || typeof obj !== 'object') return;
+        for (const key of Object.keys(obj)) {
+          if (jsonFields.has(key)) {
+            if (typeof obj[key] === 'string') {
+              try {
+                obj[key] = JSON.parse(obj[key]);
+              } catch (e) {}
+            }
+          } else if (typeof obj[key] === 'object' && obj[key] !== null) {
+            parseJsonFields(obj[key]);
+          }
+        }
+      };
+
+      this.$use(async (params, next) => {
+        if (params.args) {
+          if (params.args.data) stringifyJsonFields(params.args.data);
+          if (params.args.create) stringifyJsonFields(params.args.create);
+          if (params.args.update) stringifyJsonFields(params.args.update);
+          if (params.args.where) stringifyJsonFields(params.args.where); // For complex where clauses
+        }
+
+        const result = await next(params);
+
+        if (result) {
+          if (Array.isArray(result)) {
+            result.forEach(parseJsonFields);
+          } else {
+            parseJsonFields(result);
+          }
+        }
+        return result;
+      });
+    }
   }
 
   /**

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,20 +1,29 @@
 services:
   inker:
-    build: .
+    build:
+      context: .
+      args:
+        DB_PROVIDER: ${DB_PROVIDER:-sqlite}
+        VITE_AUTH_ENABLED: ${VITE_AUTH_ENABLED:-false}
     image: ${INKER_IMAGE:-inker:latest}
     container_name: inker
     restart: unless-stopped
     ports:
       - "${INKER_PORT:-80}:80"
     volumes:
-      - postgres_data:/var/lib/postgresql/17/main
-      - redis_data:/data
-      - uploads_data:/app/uploads
+      - ./data/postgres:/var/lib/postgresql/17/main
+      - ./data/db:/app/data
+      - ./data/redis:/data
+      - ./data/uploads:/app/uploads
     environment:
       TZ: ${TZ:-UTC}
       ADMIN_PIN: "${ADMIN_PIN:-1111}"
       INKER_PORT: "${INKER_PORT:-80}"
       DEFAULT_TIMEZONE: ${DEFAULT_TIMEZONE:-UTC}
+      DB_PROVIDER: ${DB_PROVIDER:-sqlite}
+      DATABASE_URL: ${DATABASE_URL:-file:/app/data/inker.db}
+      AUTH_ENABLED: ${AUTH_ENABLED:-false}
+      VITE_AUTH_ENABLED: ${VITE_AUTH_ENABLED:-false}
     healthcheck:
       test: ["CMD", "bun", "-e", "const r=await fetch('http://127.0.0.1/health');process.exit(r.ok?0:1)"]
       interval: 30s
@@ -22,10 +31,3 @@ services:
       retries: 3
       start_period: 60s
 
-volumes:
-  postgres_data:
-    driver: local
-  redis_data:
-    driver: local
-  uploads_data:
-    driver: local

--- a/docker/cont-init.d/01-postgres-init
+++ b/docker/cont-init.d/01-postgres-init
@@ -1,6 +1,11 @@
 #!/bin/sh
 set -e
 
+if [ "$DB_PROVIDER" != "postgresql" ]; then
+  echo "[init] PostgreSQL disabled, skipping init..."
+  exit 0
+fi
+
 PGDATA=/var/lib/postgresql/17/main
 PG17_BIN=/usr/lib/postgresql/17/bin
 PG15_BIN=/usr/lib/postgresql/15/bin

--- a/docker/services.d/backend/run
+++ b/docker/services.d/backend/run
@@ -1,12 +1,14 @@
 #!/command/with-contenv sh
 exec 2>&1
 
-# Wait for PostgreSQL to be ready
-echo "[backend] Waiting for PostgreSQL..."
-until su - postgres -c "pg_isready -q" 2>/dev/null; do
-    sleep 1
-done
-echo "[backend] PostgreSQL is ready"
+# Wait for PostgreSQL to be ready if configured
+if [ "$DB_PROVIDER" = "postgresql" ]; then
+  echo "[backend] Waiting for PostgreSQL..."
+  until su - postgres -c "pg_isready -q" 2>/dev/null; do
+      sleep 1
+  done
+  echo "[backend] PostgreSQL is ready"
+fi
 
 # Wait for Redis to be ready
 echo "[backend] Waiting for Redis..."
@@ -16,8 +18,8 @@ done
 echo "[backend] Redis is ready"
 
 # Create required directories and set ownership for non-root backend
-mkdir -p /app/uploads/screens /app/uploads/firmware /app/uploads/widgets /app/uploads/captures /app/uploads/drawings /app/logs /tmp/inker-home
-chown -R inker:inker /app/uploads /app/logs /tmp/inker-home
+mkdir -p /app/uploads/screens /app/uploads/firmware /app/uploads/widgets /app/uploads/captures /app/uploads/drawings /app/logs /tmp/inker-home /app/data
+chown -R inker:inker /app/uploads /app/logs /tmp/inker-home /app/data
 
 # Set HOME for the inker user (Puppeteer needs a writable home for config)
 export HOME=/tmp/inker-home

--- a/docker/services.d/postgres/run
+++ b/docker/services.d/postgres/run
@@ -1,2 +1,5 @@
 #!/command/with-contenv sh
+if [ "$DB_PROVIDER" != "postgresql" ]; then
+  exit 0
+fi
 exec s6-setuidgid postgres /usr/lib/postgresql/17/bin/postgres -D /var/lib/postgresql/17/main

--- a/frontend/src/components/layout/Header.tsx
+++ b/frontend/src/components/layout/Header.tsx
@@ -1,5 +1,6 @@
 import { useAuth } from '../../contexts/AuthContext';
 import { Button } from '../common';
+import { config } from '../../config';
 
 /**
  * Header component with user menu
@@ -63,27 +64,29 @@ export function Header() {
                 </div>
 
                 {/* Logout button */}
-                <Button
-                  variant="outline"
-                  size="sm"
-                  onClick={handleLogout}
-                  className="ml-2"
-                >
-                  <svg
-                    className="w-4 h-4 mr-1.5"
-                    fill="none"
-                    viewBox="0 0 24 24"
-                    stroke="currentColor"
-                    strokeWidth={1.5}
+                {config.authEnabled && (
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    onClick={handleLogout}
+                    className="ml-2"
                   >
-                    <path
-                      strokeLinecap="round"
-                      strokeLinejoin="round"
-                      d="M15.75 9V5.25A2.25 2.25 0 0013.5 3h-6a2.25 2.25 0 00-2.25 2.25v13.5A2.25 2.25 0 007.5 21h6a2.25 2.25 0 002.25-2.25V15m3 0l3-3m0 0l-3-3m3 3H9"
-                    />
-                  </svg>
-                  Logout
-                </Button>
+                    <svg
+                      className="w-4 h-4 mr-1.5"
+                      fill="none"
+                      viewBox="0 0 24 24"
+                      stroke="currentColor"
+                      strokeWidth={1.5}
+                    >
+                      <path
+                        strokeLinecap="round"
+                        strokeLinejoin="round"
+                        d="M15.75 9V5.25A2.25 2.25 0 0013.5 3h-6a2.25 2.25 0 00-2.25 2.25v13.5A2.25 2.25 0 007.5 21h6a2.25 2.25 0 002.25-2.25V15m3 0l3-3m0 0l-3-3m3 3H9"
+                      />
+                    </svg>
+                    Logout
+                  </Button>
+                )}
               </div>
             </div>
           )}

--- a/frontend/src/config.ts
+++ b/frontend/src/config.ts
@@ -65,6 +65,9 @@ export const config = {
     }
     return path;
   },
+
+  // Whether authentication is enabled
+  authEnabled: import.meta.env.VITE_AUTH_ENABLED !== 'false',
 };
 
 // Log configuration in development for debugging

--- a/frontend/src/contexts/AuthContext.tsx
+++ b/frontend/src/contexts/AuthContext.tsx
@@ -2,6 +2,7 @@
 import { createContext, useContext, useReducer, type ReactNode, useEffect } from 'react';
 import type { AuthState } from '../types';
 import { authService } from '../services/api';
+import { config } from '../config';
 
 // Session storage key
 const SESSION_KEY = 'inker_session';
@@ -22,8 +23,8 @@ type AuthAction =
 // Initial state - simplified without user
 const initialState: AuthState = {
   token: null,
-  isAuthenticated: false,
-  isLoading: true,
+  isAuthenticated: !config.authEnabled,
+  isLoading: config.authEnabled,
   error: null,
 };
 
@@ -92,6 +93,10 @@ export function AuthProvider({ children }: { children: ReactNode }) {
 
   // Restore session on mount
   useEffect(() => {
+    if (!config.authEnabled) {
+      return;
+    }
+
     const token = localStorage.getItem(SESSION_KEY);
 
     if (token) {


### PR DESCRIPTION
- Introduce DB_PROVIDER env var to toggle between postgresql and sqlite
- Implement backend/scripts to dynamically modify Prisma schema and types for SQLite compatibility
- Add AUTH_ENABLED and VITE_AUTH_ENABLED toggles to skip password authentication
- Refactor docker-compose.yml to use local directories instead of named volumes for easier data access
- Optimize Dockerfile to conditionally install PostgreSQL based on DB_PROVIDER