### PR TITLE
Fix weather icons and emoji not rendering on e-ink device (#23)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -91,7 +91,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     nginx \
     # Chrome headless shell dependencies
     wget ca-certificates openssl unzip \
-    fonts-liberation fonts-noto-color-emoji fonts-noto-cjk fontconfig \
+    fonts-liberation fonts-symbola fonts-noto-cjk fontconfig \
     libnss3 libatk-bridge2.0-0t64 libdrm2 libxkbcommon0 \
     libgbm1 libxcomposite1 libxdamage1 libxfixes3 libxrandr2 \
     libasound2t64 libcups2t64 libatk1.0-0t64 libnspr4 libdbus-1-3 \

--- a/backend/src/screen-designer/services/screen-renderer.service.ts
+++ b/backend/src/screen-designer/services/screen-renderer.service.ts
@@ -776,9 +776,9 @@ export class ScreenRendererService implements OnModuleDestroy, OnModuleInit {
           <ellipse cx="${cx - 5}" cy="${cy - 5}" rx="${r * 0.7}" ry="${r * 0.5}" fill="${color}"/>
           <ellipse cx="${cx + 6}" cy="${cy - 5}" rx="${r * 0.6}" ry="${r * 0.45}" fill="${color}"/>
           <ellipse cx="${cx}" cy="${cy - 10}" rx="${r * 0.85}" ry="${r * 0.6}" fill="${color}"/>
-          <text x="${cx - 8}" y="${cy + 12}" font-size="12" fill="${color}">*</text>
-          <text x="${cx}" y="${cy + 16}" font-size="12" fill="${color}">*</text>
-          <text x="${cx + 8}" y="${cy + 10}" font-size="12" fill="${color}">*</text>
+          <text x="${cx - 8}" y="${cy + 12}" font-size="12" font-family="sans-serif" fill="${color}">*</text>
+          <text x="${cx}" y="${cy + 16}" font-size="12" font-family="sans-serif" fill="${color}">*</text>
+          <text x="${cx + 8}" y="${cy + 10}" font-size="12" font-family="sans-serif" fill="${color}">*</text>
         `;
       case 'thunder':
         return `
@@ -2961,7 +2961,7 @@ export class ScreenRendererService implements OnModuleDestroy, OnModuleInit {
 
       html += '<div style="display: flex; align-items: center; gap: 8px;">';
       if (showIcon) {
-        html += `<div style="color: currentColor;">${this.getWeatherIconSvg(condition.icon, iconSize, 'currentColor')}</div>`;
+        html += `<svg width="${iconSize}" height="${iconSize}" viewBox="0 0 ${iconSize} ${iconSize}" xmlns="http://www.w3.org/2000/svg" style="color: currentColor;">${this.getWeatherIconSvg(condition.icon, iconSize, 'currentColor')}</svg>`;
       }
       html += '<div style="display: flex; flex-direction: column;">';
       if (showTemperature) {

--- a/backend/src/screen-designer/services/screen-renderer.service.ts
+++ b/backend/src/screen-designer/services/screen-renderer.service.ts
@@ -149,16 +149,19 @@ export class ScreenRendererService implements OnModuleDestroy, OnModuleInit {
    * This ensures the loaded woff2 fonts are actually used
    */
   private mapFontFamily(fontFamily: string): string {
+    // 'Symbola' is a monochrome symbol/emoji font (installed in the image). It is
+    // listed as a per-glyph fallback so emoji render as black glyphs that survive
+    // the grayscale + Floyd-Steinberg dithering for e-ink (color emoji turn white).
     switch (fontFamily) {
       case 'sans-serif':
-        return "'Inter', sans-serif";
+        return "'Inter', 'Symbola', sans-serif";
       case 'monospace':
-        return "'Roboto Mono', monospace";
+        return "'Roboto Mono', 'Symbola', monospace";
       case 'serif':
-        return "'Merriweather', serif";
+        return "'Merriweather', 'Symbola', serif";
       default:
         // If already a specific font or unknown, return with fallback
-        return fontFamily.includes(',') ? fontFamily : `${fontFamily}, sans-serif`;
+        return fontFamily.includes(',') ? fontFamily : `${fontFamily}, 'Symbola', sans-serif`;
     }
   }
 


### PR DESCRIPTION
Fixes the weather icons (and, while at it, emoji) being invisible on the physical e-ink device although they show correctly in the designer preview. Reported in #23 (firmware 1.7.8, v0.4.0). Both issues are verified fixed on a real device.

## 1. Weather icons missing on device

`generateWeatherContent()` embedded the raw SVG primitives returned by `getWeatherIconSvg()` (`<circle>`, `<ellipse>`, `<line>`, …) directly into an HTML `<div>`, without an enclosing `<svg>` element. Browsers only render SVG primitives inside an `<svg>`, so on the Puppeteer device-render path the icon produced no pixels — while the frontend designer preview (`WidgetRenderer.tsx`'s `WeatherIcon`, which uses a proper `<svg>` wrapper) showed it fine. The sibling battery/wifi widgets already wrap their icons correctly; weather was the outlier.

- Wrap the icon markup in a sized `<svg ... viewBox>` element (matching the battery/wifi pattern).
- Add `font-family` to the snow glyph `<text>` elements for robust rendering.

## 2. Emoji vanish on device

Color emoji (e.g. `⚡` via `fonts-noto-color-emoji`) render bright/yellow, which the grayscale + Floyd-Steinberg pass pushes above the white threshold (140) → they turn white and disappear on the device, while showing in the browser preview.

- Swap the color emoji font for the monochrome **Symbola** font (`fonts-symbola`, the monochrome emoji/symbol font available in Debian trixie) and list it as a per-glyph fallback in `mapFontFamily()`, so emoji render as black glyphs that survive dithering. No widget-content changes needed.
- Trade-off: emoji are now rendered monochrome instead of in color — which is the desired behaviour for a 1-bit e-ink display anyway.

## Testing

Built and deployed to a real TRMNL device (firmware 1.7.8): the weather forecast icons now render, and the `⚡` in a text/custom widget now shows as a black glyph.

<img width="1129" height="756" alt="image" src="https://github.com/user-attachments/assets/04c69793-a792-4bf8-8a95-8476f058c997" />


Closes #23

🤖 Generated with [Claude Code](https://claude.com/claude-code)